### PR TITLE
Fix `getFilteredSettings` method to set default `$type` and validate option settings.

### DIFF
--- a/CRM/Cdashtabs/Settings.php
+++ b/CRM/Cdashtabs/Settings.php
@@ -72,7 +72,7 @@ class CRM_Cdashtabs_Settings {
    * @param string $type Entity type ('uf_group' or 'native')
    *
    */
-  public static function getFilteredSettings($isCdash = NULL, $type) {
+  public static function getFilteredSettings($isCdash = NULL, $type = "") {
     $filteredSettings = [];
     // Get cdashtabs optionGroup and all of its optionValues.
     $optionGroup = \Civi\Api4\OptionGroup::get()
@@ -85,8 +85,9 @@ class CRM_Cdashtabs_Settings {
       $optionSettingJson = $optionValue['value'] ?? '{}';
       $optionSettings = json_decode($optionSettingJson, TRUE);
       if (
-        $optionSettings["{$type}_id"]
-        && ($isCdash === NULL || ($optionSettings['is_cdash'] ?? 0) == intval($isCdash))
+        is_array($optionSettings) &&
+        !empty($optionSettings["{$type}_id"]) &&
+        ($isCdash === NULL || ($optionSettings['is_cdash'] ?? 0) == intval($isCdash))
       ) {
         $filteredSettings[] = $optionSettings;
       }


### PR DESCRIPTION
This PR fixes a warning and improves the robustness of the `getFilteredSettings` method in the `cdashtabs` extension.

#### ✅ Changes made:

* Added a default empty string value for the `$type` parameter to prevent missing argument warnings.
* Added `is_array()` check for decoded JSON (`$optionSettings`) to avoid "access array offset on int" warnings.
* Improved the conditional logic to ensure we only access expected keys when the structure is valid.

#### 🛠 Why this fix was needed:

In cases where it returned a scalar or `NULL` (e.g., due to malformed or empty JSON), attempting to access keys like `$optionSettings["{$type}_id"]` caused PHP warnings such as:

```
Warning: Trying to access array offset on value of type int
```

By ensuring `$optionSettings` is an array before accessing keys, we prevent runtime warnings and improve stability.

✅ Ready for review and merge.
Let me know if any changes or clarifications are needed!