### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Cdashtabs/Form/Settings.php
+++ b/CRM/Cdashtabs/Form/Settings.php
@@ -187,7 +187,7 @@ class CRM_Cdashtabs_Form_Settings extends CRM_Core_Form {
   public function setDefaultValues() {
     $result = _cdashtabs_civicrmapi('setting', 'get', array('return' => array_keys($this->_settings)));
     $domainID = CRM_Core_Config::domainID();
-    $ret = CRM_Utils_Array::value($domainID, $result['values']);
+    $ret = $result['values'][$domainID] ?? NULL;
     return $ret;
   }
 

--- a/CRM/Cdashtabs/Settings.php
+++ b/CRM/Cdashtabs/Settings.php
@@ -46,7 +46,7 @@ class CRM_Cdashtabs_Settings {
 
     $createParams = array();
 
-    if ($optionValueId = CRM_Utils_Array::value('id', $result)) {
+    if ($optionValueId = $result['id'] ?? NULL) {
       $createParams['id'] = $optionValueId;
     }
     else {


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.