### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Cdashtabs/Upgrader.php
+++ b/CRM/Cdashtabs/Upgrader.php
@@ -83,7 +83,7 @@ class CRM_Cdashtabs_Upgrader extends CRM_Extension_Upgrader_Base {
           ->execute();
       }
     }
-    catch (API_Exception $e) {
+    catch (CRM_Core_Exception $e) {
     }
   }
 

--- a/cdashtabs.php
+++ b/cdashtabs.php
@@ -399,7 +399,7 @@ function cdashtabs_civicrm_alterContent(&$content, $context, $tplName, &$object)
 /**
  * Log CiviCRM API errors to CiviCRM log.
  */
-function _cdashtabs_log_api_error(API_Exception $e, string $entity, string $action, array $params) {
+function _cdashtabs_log_api_error(CRM_Core_Exception $e, string $entity, string $action, array $params) {
   $message = "CiviCRM API Error '{$entity}.{$action}': " . $e->getMessage() . '; ';
   $message .= "API parameters when this error happened: " . json_encode($params) . '; ';
   $bt = debug_backtrace();
@@ -416,7 +416,7 @@ function _cdashtabs_civicrmapi(string $entity, string $action, array $params, bo
   try {
     $result = civicrm_api3($entity, $action, $params);
   }
-  catch (API_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     _cdashtabs_log_api_error($e, $entity, $action, $params);
     if (!$silence_errors) {
       throw $e;


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.