### PR TITLE
Ensure group selectors render correctly

### DIFF
--- a/CRM/Cdashtabs/Utils.php
+++ b/CRM/Cdashtabs/Utils.php
@@ -59,7 +59,7 @@ class CRM_Cdashtabs_Utils {
     $ret[] = $fieldNameContactType;
 
     $fieldNameGroup = $prefix . 'group';
-    $groupOptions = CRM_Core_PseudoConstant::nestedGroup();
+    $groupOptions = CRM_Core_PseudoConstant::nestedGroup(TRUE, NULL, TRUE, "plain");
     $form->add('select', $fieldNameGroup, E::ts('Display only for contacts in group(s)'), $groupOptions, FALSE, [
       'multiple' => 'multiple',
       'class' => 'crm-select2',


### PR DESCRIPTION
In 6.13 select dropdowns always escape html which causes group selectors to look bad.
This passes the new to param to format the group hierarchy in a plain text compatible format.

This change is backward-compatible; in CiviCRM < 6.13 the new param will be ignored.